### PR TITLE
Fix: Detect default Python version in dstack CLI environment

### DIFF
--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -27,10 +27,6 @@ from dstack._internal.server.services.docker import ImageConfig, get_image_confi
 from dstack._internal.server.utils.common import run_async
 
 
-import sys
-from dstack._internal.core.errors import ServerClientError
-from dstack._internal.core.models.configurations import PythonVersion
-
 def get_default_python_version() -> str:
     """
     Detect the default Python version from the user's environment in the CLI.


### PR DESCRIPTION
- Improved error handling to inform users if their Python version is unsupported.
- Updated the get_default_python_version function to retrieve the Python version from the local CLI environment instead of the dstack-server.